### PR TITLE
🧪 Add test coverage for exception handling fallback in generate_net.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ npm-debug.log
 
 # macOS
 .DS_Store
+.coverage
+__pycache__/

--- a/tests/test_generate_net.py
+++ b/tests/test_generate_net.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import unittest.mock
+import pytest
+
+# Add the project root to the path so we can import from scripts
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from scripts.petri_net_generation.generate_net import main
+
+def test_exception_handling_creates_empty_files(tmp_path):
+    """
+    Test that when an exception occurs during Petri net generation
+    (e.g., input file not found), the script creates empty output files
+    to satisfy Make dependencies.
+    """
+    input_file = "non_existent_input.md"
+    output_pnml = os.path.join(tmp_path, "output", "test_output.pnml")
+
+    # Run the main function with mocked arguments
+    with unittest.mock.patch('sys.argv', ['generate_net.py', input_file, output_pnml]):
+        main()
+
+    # The script should have created the output directory and empty files
+    assert os.path.exists(output_pnml), "Empty PNML file was not created"
+    assert os.path.getsize(output_pnml) == 0, "PNML file is not empty"
+
+    output_png = os.path.splitext(output_pnml)[0] + ".png"
+    assert os.path.exists(output_png), "Empty PNG visualization file was not created"
+    assert os.path.getsize(output_png) == 0, "PNG file is not empty"


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for the exception handling and fallback logic inside `scripts/petri_net_generation/generate_net.py`. Previously, the code that generates empty `.pnml` and `.png` files on error was untested.
📊 **Coverage:** The test simulates a `FileNotFoundError` by mocking `sys.argv` with a nonexistent input markdown file path and validates that the script creates empty files in the expected output directory to satisfy build dependencies like Make.
✨ **Result:** The fallback block handling exceptions is now fully verified by the test suite, preventing regressions. The PR also improves repository hygiene by adding `.coverage` and `__pycache__/` to `.gitignore`.

---
*PR created automatically by Jules for task [9315754543269351332](https://jules.google.com/task/9315754543269351332) started by @edithatogo*